### PR TITLE
Merge fix_download branch

### DIFF
--- a/pyedgar/__init__.py
+++ b/pyedgar/__init__.py
@@ -13,7 +13,7 @@ Files from the SEC reside at https://www.sec.gov/Archives/edgar/data/CIK/ACCESSI
 """
 
 __title__ = 'pyedgar'
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 __version_info__ = tuple(int(i) for i in __version__.split("."))
 __author__ = 'Mac Gaulin'
 __license__ = 'MIT'

--- a/pyedgar/config.py
+++ b/pyedgar/config.py
@@ -196,7 +196,6 @@ _defaults = {
     "KEEP_REGEX": "",
     "INDEX_DELIMITER": "\t",
     "INDEX_EXTENSION": "tab",
-    "INDEX_FILE_COMPRESSION": "",
     "USER_AGENT": "pyedgar feed download by YOUREMAIL@example.com, from code at https://github.com/gaulinmp/pyedgar",
 }
 
@@ -351,14 +350,10 @@ def format_index_cache_path(datetime_or_yearQN_str):
     # Get that thing from above.
     global INDEX_CACHE_PATH_FORMAT
 
-    def get_yr_qtr_from_str(yq_string, *, yr_re=re.compile(r"(?P<year>(?:20|19)\d\d)Q?(?P<qtr>[1234])", re.I)):
+    def get_yr_qtr_from_str(yq_string, *, yr_re=re.compile(r"([12]\d{3})Q?([1234])", re.I)):
         """Get year/qtr from string"""
-        try:
-            yq_dict = yr_re.search(yq_string).groupdict()
-        except AttributeError:
-            return (1990, 0)
-
-        return int(yq_dict["year"]), int(yq_dict["qtr"])
+        yq = yr_re.search(yq_string)
+        return tuple(int(x) for x in yq.groups()) if yq else (1990, 0)
 
     try:
         year = datetime_or_yearQN_str.year

--- a/pyedgar/config.py
+++ b/pyedgar/config.py
@@ -69,6 +69,9 @@ INDEX_CACHE_PATH_FORMAT=full_index_{year}_Q{quarter}.gz
 KEEP_ALL=True
 KEEP_REGEX=
 
+; User Agent for downloading, to keep the SEC happy
+USER_AGENT=pyedgar feed download by YOUREMAIL@example.com, from code at https://github.com/gaulinmp/pyedgar
+
 [Index]
 ; Index file settings
 INDEX_DELIMITER=\t
@@ -194,6 +197,7 @@ _defaults = {
     "INDEX_DELIMITER": "\t",
     "INDEX_EXTENSION": "tab",
     "INDEX_FILE_COMPRESSION": "",
+    "USER_AGENT": "pyedgar feed download by YOUREMAIL@example.com, from code at https://github.com/gaulinmp/pyedgar",
 }
 
 CONFIG_FILE = get_config_file()
@@ -249,6 +253,7 @@ INDEX_CACHE_PATH_FORMAT = CONFIG_OBJECT.get("Paths", "INDEX_CACHE_PATH_FORMAT")
 CACHE_FEED = CONFIG_OBJECT.getboolean("Paths", "CACHE_FEED")
 KEEP_ALL = CONFIG_OBJECT.getboolean("Downloader", "KEEP_ALL")
 KEEP_REGEX = CONFIG_OBJECT.get("Downloader", "KEEP_REGEX")
+USER_AGENT = CONFIG_OBJECT.get("Downloader", "USER_AGENT")
 
 # Index cache settings
 CACHE_INDEX = CONFIG_OBJECT.getboolean("Paths", "CACHE_INDEX")

--- a/pyedgar/downloader.py
+++ b/pyedgar/downloader.py
@@ -10,24 +10,86 @@ Download script to download and cache feeds and indices.
 # Stdlib imports
 import os
 import re
-# import tarfile
 import logging
+import subprocess
 import datetime as dt
 from time import sleep
-from subprocess import Popen
 
 # 3rd party imports
 
 # Module Imports
 from pyedgar import config
+from pyedgar import utilities
 from pyedgar.utilities import edgarcache
-# from pyedgar.utilities import edgarweb
-# from pyedgar.utilities import forms
+from pyedgar.utilities import edgarweb
 from pyedgar.utilities import indices
+
 # from pyedgar.utilities import localstore
 
 # Local logger
 _logger = logging.getLogger(__name__)
+
+
+def download_feed(date, overwrite=False, use_requests=False, overwrite_size_threshold=8 * 1024):
+    """Download edgar daily feed compressed file.
+
+    Args:
+        date (datetime, str): Date of feed file to download. Can be datetime
+            or string (YYYYMMDD format with optional spacing).
+        overwrite (bool): Flag for whether to overwrite any existing file (default False).
+        use_requests (bool): Flag for whether to use requests or curl (default False == curl).
+        overwrite_size_threshold (int): Existing files smaller than this will be re-downloaded.
+
+    Returns:
+        tuple: output file path, return code
+    """
+    date = utilities.datetime_from_string(date)
+
+    feed_path = config.get_feed_cache_path(date)
+    url = edgarweb.get_feed_url(date)
+
+    return edgarweb.download_from_edgar(
+        url,
+        feed_path,
+        overwrite=overwrite,
+        use_requests=use_requests,
+        overwrite_size_threshold=overwrite_size_threshold,
+    )
+
+
+def download_feeds_recursively(start_date, end_date=None, overwrite=False, use_requests=False, overwrite_size_threshold=8 * 1024):
+    """Download edgar daily feed compressed files recursively from start to end.
+    If `end_date` is `None`, default to today.
+    Error downloads, or rate limited downloads are around 6kb, thus set the overwrite_size_threshold to larger than that
+    to automatically re-download those error files.
+
+    Args:
+        start_date (datetime, str): Starting date of feeds to download. Can be datetime
+            or string (YYYYMMDD format with optional spacing).
+        end_date (None,datetime, str): Ending date of feeds to download (default today).
+            Can be datetime or string (YYYYMMDD format with optional spacing).
+        overwrite (bool): Flag for whether to overwrite any existing file (default False).
+        use_requests (bool): Flag for whether to use requests or curl (default False == curl).
+        overwrite_size_threshold (int): Existing files smaller than this will be re-downloaded.
+
+    Returns:
+        tuple: output file path, return code
+    """
+    start_date = utilities.datetime_from_string(start_date)
+    end_date = utilities.datetime_from_string(end_date or dt.datetime.today())
+
+    _dls = []
+    for i_date in range(start_date.toordinal(), end_date.toordinal()):
+        i_dt = dt.date.fromordinal(i_date)
+        try:
+            _dl = download_feed(i_dt, overwrite=overwrite, use_requests=use_requests, overwrite_size_threshold=overwrite_size_threshold)
+            _dls.append(_dl)
+            _logger.info("Done downloading %r", i_dt)
+        except Exception as e:
+            _logger.exception("Error downloading %r: %r", i_dt, e)
+        sleep(1)
+
+    return _dls
 
 
 def main(start_date=None, last_n_days=None, get_indices=True, download_feeds=True, extract_feeds=True):
@@ -52,15 +114,14 @@ def main(start_date=None, last_n_days=None, get_indices=True, download_feeds=Tru
     """
     rgx = re.compile(config.KEEP_REGEX, re.I) if not config.KEEP_ALL else None
     _logger.info("From Config: keep regex: %r", rgx)
-    cacher = edgarcache.EDGARCacher(keep_form_type_regex=rgx, check_cik='cik' in config.FILING_PATH_FORMAT)
+    cacher = edgarcache.EDGARCacher(keep_form_type_regex=rgx, check_cik="cik" in config.FILING_PATH_FORMAT)
 
     if start_date is None:
         start_date = dt.date.fromordinal(dt.date.today().toordinal() - (last_n_days or 30))
 
     if download_feeds:
         _logger.info("Downloading since {:%Y-%m-%d}...".format(start_date))
-        for _ in cacher.download_many_feeds(start_date):
-            pass
+        download_feeds_recursively(start_date, overwrite=False)
 
     if extract_feeds:
         _logger.info("Extracting since {:%Y-%m-%d}...".format(start_date))
@@ -75,111 +136,110 @@ def main(start_date=None, last_n_days=None, get_indices=True, download_feeds=Tru
     _logger.info("Done")
 
 
-
-def download_feed(date, overwrite=True):
-    """Download edgar daily feed compressed file.
-
-    Args:
-        date (datetime, str): Date of feed file to download. Can be datetime
-            or string (YYYYMMDD format with optional spacing).
-        overwrite (bool): Flag for whether to overwrite any existing file.
-    """
-    if isinstance(date, str):
-        date, date_input = re.sub('[^0-9]', '', date), date
-        if len(date) != 8:
-            _logger.error("Date must be in YYYYMMDD format (spacing ignored). You passed: %r", date_input)
-            return
-        date = dt.datetime(date[:4], date[4:6], date[6:])
-
-    feed_path = config.get_feed_cache_path(date)
-
-
-    if os.path.exists(feed_path):
-        if not overwrite:
-            _logger.warning('Skipping existing cache file at: %r', feed_path)
-            return
-
-        _logger.warning('Removing existing file at %r', feed_path)
-        os.remove(feed_path)
-
-    year, month, day = date.year, date.month, date.day
-    qtr = (month-1)//3+1
-    url = f"https://www.sec.gov/Archives/edgar/Feed/{year}/QTR{qtr}/{year}{month:02d}{day:02d}.nc.tar.gz"
-
-    _logger.info("curl %s -o %s", url, feed_path)
-    return Popen(['curl', url, '-o', feed_path])
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     from argparse import ArgumentParser
 
-    argp = ArgumentParser(description='Downloader for pyedgar, downloads past'
-                                      ' 30 days (or since DATE or last_n_days) of forms and'
-                                      ' all indices (unless -f or -i flags'
-                                      ' respectively are set).')
+    argp = ArgumentParser(
+        description="Downloader for pyedgar, downloads past"
+        " 30 days (or since DATE or last_n_days) of forms and"
+        " all indices (unless -f or -i flags"
+        " respectively are set)."
+    )
 
-    argp.add_argument('-s', '--start-date', default=None,
-                      dest='start_date', metavar='YYYY-MM-DD',
-                      type=lambda s: dt.datetime.strptime(s, "%Y-%m-%d"),
-                      help='An optional date of form YYYY-MM-DD to start '
-                           'downloading indices from')
+    argp.add_argument(
+        "-s",
+        "--start-date",
+        default=None,
+        dest="start_date",
+        metavar="YYYY-MM-DD",
+        type=lambda s: dt.datetime.strptime(s, "%Y-%m-%d"),
+        help="An optional date of form YYYY-MM-DD to start " "downloading indices from",
+    )
 
-    argp.add_argument('-n', '--last-n-days', default=30, dest='last_n_days', type=int,
-                      help='An optional integer for the last number of days '
-                           'to start downloading indices from')
+    argp.add_argument(
+        "-n",
+        "--last-n-days",
+        default=30,
+        dest="last_n_days",
+        type=int,
+        help="An optional integer for the last number of days " "to start downloading indices from",
+    )
 
-    argp.add_argument('-i', '--indices', action='store_true', dest='get_indices',
-                      help='Download and update indices.')
-    argp.add_argument('-d', '--download-feeds', action='store_true', dest='download_feeds',
-                      help='Do not download or extract daily feed feeds.')
-    argp.add_argument('-e', '--extract-feeds', action='store_true', dest='extract_feeds',
-                      help='Do not extract daily feed feeds.')
+    argp.add_argument("-i", "--indices", action="store_true", dest="get_indices", help="Download and update indices.")
+    argp.add_argument(
+        "-d",
+        "--download-feeds",
+        action="store_true",
+        dest="download_feeds",
+        help="Do not download or extract daily feed feeds.",
+    )
+    argp.add_argument(
+        "-e", "--extract-feeds", action="store_true", dest="extract_feeds", help="Do not extract daily feed feeds."
+    )
 
-    argp.add_argument('--log-level', dest='log_level', default='error',
-                      help='Set the log-level to display more/less output. '
-                           'Choose from: error (default), warning, info, debug.')
+    argp.add_argument(
+        "--log-level",
+        dest="log_level",
+        default="error",
+        help="Set the log-level to display more/less output. " "Choose from: error (default), warning, info, debug.",
+    )
 
     cl_args = argp.parse_args()
 
-    _log_level = {
-        'w': logging.WARNING,
-        'i': logging.INFO,
-        'd': logging.DEBUG,
-        }.get(cl_args.log_level[0].lower(), logging.ERROR)
+    _log_level = {"w": logging.WARNING, "i": logging.INFO, "d": logging.DEBUG,}.get(
+        cl_args.log_level[0].lower(), logging.ERROR
+    )
 
     logging.basicConfig(level=_log_level)
 
-    main(start_date=cl_args.start_date,
-         last_n_days=cl_args.last_n_days,
-         get_indices=cl_args.get_indices,
-         download_feeds=cl_args.download_feeds,
-         extract_feeds=cl_args.extract_feeds)
+    main(
+        start_date=cl_args.start_date,
+        last_n_days=cl_args.last_n_days,
+        get_indices=cl_args.get_indices,
+        download_feeds=cl_args.download_feeds,
+        extract_feeds=cl_args.extract_feeds,
+    )
 
 
-if __name__ == 'NOT __main__':
+if __name__ == "NOT __main__":
     from argparse import ArgumentParser
 
-    argp = ArgumentParser(description='Redownload daily feed file.')
+    argp = ArgumentParser(description="Redownload daily feed file.")
 
-    argp.add_argument('-d', '--date', default=None,
-                      dest='date', metavar='YYYY-MM-DD',
-                      type=lambda s: dt.datetime.strptime(s, "%Y-%m-%d"),
-                      help='The date to download in form YYYY-MM-DD')
+    argp.add_argument(
+        "-d",
+        "--date",
+        default=None,
+        dest="date",
+        metavar="YYYY-MM-DD",
+        type=lambda s: dt.datetime.strptime(s, "%Y-%m-%d"),
+        help="The date to download in form YYYY-MM-DD",
+    )
 
-    argp.add_argument('-r', '--recursive', default=False, action="store_true",
-                      dest='recursive',
-                      help='Recursively download from date till today.')
+    argp.add_argument(
+        "-r",
+        "--recursive",
+        default=False,
+        action="store_true",
+        dest="recursive",
+        help="Recursively download from date till today.",
+    )
 
-    argp.add_argument('-t', '--today', default=False, action="store_true",
-                      dest='get_today',
-                      help='Get the last 2 days of downloads (if missing)')
+    argp.add_argument(
+        "-t",
+        "--today",
+        default=False,
+        action="store_true",
+        dest="get_today",
+        help="Get the last 2 days of downloads (if missing)",
+    )
 
     cl_args = argp.parse_args()
     _logger.info(cl_args)
     _logger.warning("Downloading to %r", config.FEED_CACHE_ROOT)
 
     if cl_args.get_today:
-        for i_date in range(dt.date.today().toordinal()-2, dt.date.today().toordinal()):
+        for i_date in range(dt.date.today().toordinal() - 2, dt.date.today().toordinal()):
             i_date = dt.date.fromordinal(i_date)
             print(f"Downloading {i_date:%Y-%m-%d}")
             subp = download_feed(i_date, overwrite=False)

--- a/pyedgar/downloader.py
+++ b/pyedgar/downloader.py
@@ -44,11 +44,11 @@ def main(start_date=None, last_n_days=30, get_indices=False, get_feeds=False, us
     Examples:
         This will download/extract last 30 days of forms and all indices:
 
-            ```python -m pyedgar.downloader -i -d -e --last-n-days 30```
+            ```python -m pyedgar.downloader -i -d --last-n-days 30```
 
-        This will just extract the already downloaded last 30 days of forms and ignore indices:
+        This will download and extract the last 7 days of forms:
 
-            ```python -m pyedgar.downloader -e --last-n-days 30```
+            ```python -m pyedgar.downloader -d --last-n-days 7```
 
     Args:
         start_date (date): Date to start extraction of feeds from. When empty, defaults to today() - last_n_days
@@ -98,6 +98,24 @@ def main(start_date=None, last_n_days=30, get_indices=False, get_feeds=False, us
         index_maker.extract_indexes()
         _logger.info("Done downloading and extracting indices")
 
+
+def print_cache_status():
+    for i_date in reversed(list(utilities.iterate_dates(1995))):
+        _feedfile = config.get_feed_cache_path(i_date)
+        if os.path.exists(_feedfile):
+            break
+    else:
+        _feedfile = None
+
+    for i_date in reversed(list(utilities.iterate_dates(1995, period='quarterly'))):
+        _idxfile = config.get_index_cache_path(i_date)
+        if os.path.exists(_idxfile):
+            break
+    else:
+        _idxfile = None
+
+    print("Last downloaded feed cache: ", _feedfile)
+    print("Last downloaded index cache:", _idxfile)
 
 def print_config():
     """Prints out config file"""
@@ -162,6 +180,8 @@ if __name__ == "__main__":
 
     argp.add_argument("--config", action="store_true", dest="print_config", help="Print config file settings.")
 
+    argp.add_argument("--status", action="store_true", dest="print_status", help="Show last downloaded feed and index cache files.")
+
     argp.add_argument(
         "--log",
         "--log-level",
@@ -179,6 +199,9 @@ if __name__ == "__main__":
     logging.basicConfig(level=_log_level)
 
     _logger.debug("Running with args: %r", cl_args)
+
+    if cl_args.print_status:
+        print_cache_status()
 
     if cl_args.print_config:
         print_config()

--- a/pyedgar/downloader.py
+++ b/pyedgar/downloader.py
@@ -45,6 +45,9 @@ def download_feed(date, overwrite=False, use_requests=False, overwrite_size_thre
     """
     date = utilities.datetime_from_string(date)
 
+    if date.weekday() >= 5: # sat/sun
+        return None
+
     feed_path = config.get_feed_cache_path(date)
     url = edgarweb.get_feed_url(date)
 
@@ -84,7 +87,7 @@ def download_feeds_recursively(start_date, end_date=None, overwrite=False, use_r
         try:
             _dl = download_feed(i_dt, overwrite=overwrite, use_requests=use_requests, overwrite_size_threshold=overwrite_size_threshold)
             _dls.append(_dl)
-            _logger.info("Done downloading %r", i_dt)
+            if _dl: _logger.info("Done downloading %r", i_dt)
         except Exception as e:
             _logger.exception("Error downloading %r: %r", i_dt, e)
         sleep(1)

--- a/pyedgar/index.py
+++ b/pyedgar/index.py
@@ -20,10 +20,6 @@ import pandas as pd
 # Module Imports
 from pyedgar import config
 from pyedgar.utilities.indices import IndexMaker as _IndexMaker
-# from pyedgar.utilities import edgarweb
-# from pyedgar.utilities import edgarcache
-# from pyedgar.utilities import forms
-# from pyedgar.utilities import localstore
 
 
 class EDGARIndex():

--- a/pyedgar/pyedgar.conf
+++ b/pyedgar/pyedgar.conf
@@ -59,6 +59,9 @@ KEEP_ALL=False
 ; This will be ignored if KEEP_ALL=True
 KEEP_REGEX=10-[KQ]|10[KQ]SB|8-K|(?:14A$)|13[FDG]
 
+; User Agent for downloading, to keep the SEC happy
+USER_AGENT=pyedgar feed download by gaulinmp@gmail.com, from code at https://github.com/gaulinmp/pyedgar
+
 [Index]
 ; Index file settings
 INDEX_DELIMITER=\t

--- a/pyedgar/utilities/__init__.py
+++ b/pyedgar/utilities/__init__.py
@@ -150,7 +150,7 @@ def parse_date_input(
     yr_re=__re.compile(r"[12]\d{3}"),
 ):
     """
-    Casts something to a date.
+    Casts something to a date, defaulting to yesterday if nothing is passed in.
     The something can be:
 
         date: dt.date(2000, 1, 1)
@@ -163,7 +163,7 @@ def parse_date_input(
             quarters will be on the 1st day of the 1st month in the quarter.
     """
     if default is None or not hasattr(default, "year"):
-        default = __dt.date.today()
+        default = __dt.date.fromordinal(__dt.date.today().toordinal() - 1)
     _d = None  # keep _d None until it's date, easier for ifs below
 
     if date is None:
@@ -219,7 +219,7 @@ def iterate_dates(from_date, to_date=None, period="daily", skip_weekends=True, i
         from_date (str, datetime, int): Can be datetime, year (int or string), string of format YYYYMMDD
             or YYYY-M-D, or string of format YYYYq[1234].
         to_date (str, datetime, int, None): Can be datetime, year (int or string), string of format YYYYMMDD
-            or YYYY-M-D, or string of format YYYYq[1234]. Default: today.
+            or YYYY-M-D, or string of format YYYYq[1234]. Default: yesterday.
         period (str): Periodicity of dates yielded, either `yearly`, `quarterly`, or `daily`. Default to daily.
         skip_weekends (bool): Flag for whether to skip returning weekends (sat/sun). Default: True.
         inclusive (bool): Flag for whether to include the to_date (or the quarter/year of to_date). Default: True.

--- a/pyedgar/utilities/__init__.py
+++ b/pyedgar/utilities/__init__.py
@@ -9,10 +9,55 @@ These utilities represent lower level functionality, used by the main modules.
 :license: MIT, see LICENSE for more details.
 """
 
+# Stdlib imports
+import re as __re
+import datetime as __dt
+import logging as __logging
 
-# Include sub-modules
-# from pyedgar import edgarweb
-# from pyedgar import forms
-# from pyedgar import htmlparse
-# from pyedgar import localstore
-# from pyedgar import plaintext
+__logger = __logging.getLogger(__name__)
+
+def get_cik_acc(cik, accession=None):
+    """
+    I found myself wanting to accept flexible cik/acc inputs, and wrote this
+    input parsing over and over. So finally we'll DRY and centralize.
+
+    Arguments:
+        cik (str,dict,object): String CIK, or object with cik and accession attributes or keys.
+        accession (str): String ACCESSION number, or None if accession in CIK object.
+
+    Returns:
+        tuple: Tuple of (cik, accession)
+    """
+    try:  # cik has cik/acc attributes?
+        accession = cik.accession if accession is None else accession
+        cik = cik.cik
+    except AttributeError:
+        try:  # cik is dict?
+            accession = cik.get("accession") if accession is None else accession
+            cik = cik.get("cik")
+        except AttributeError:
+            # Hopefully cik is a cik, and acc is an acc
+            cik = int(cik)
+
+    # why this would happen, who knows. But it might?
+    if accession is not None and not isinstance(accession, str):
+        try:  # acc has acc attribute?
+            accession = accession.accession
+        except AttributeError:
+            try:  # acc is dict?
+                accession = accession.get("accession")
+            except AttributeError:
+                # Whelp, we tried. Errors will abound downstream.
+                pass
+
+    return cik, accession
+
+def datetime_from_string(date):
+    """Convert string date in YYYY-MM-DD format to datetime object."""
+    if isinstance(date, str):
+        date, date_input = __re.sub('[^0-9]', '', date), date
+        if len(date) != 8:
+            __logger.error("Date must be in YYYYMMDD format (spacing ignored). You passed: %r", date_input)
+            return
+        date = __dt.datetime(int(date[:4]), int(date[4:6]), int(date[6:]))
+    return date

--- a/pyedgar/utilities/__init__.py
+++ b/pyedgar/utilities/__init__.py
@@ -17,41 +17,128 @@ import logging as __logging
 __logger = __logging.getLogger(__name__)
 
 
-def get_cik_acc(cik, accession=None):
+def get_cik_acc(*args, additional_extract=None, accession_pattern=__re.compile("\d{10}-?\d{2}-?\d{6}"), **kwargs):
     """
     I found myself wanting to accept flexible cik/acc inputs, and wrote this
     input parsing over and over. So finally we'll DRY and centralize.
 
+    Examples:
+        Can be called in any of the following ways::
+
+            cik,acc = 1750, '1234567890-12-123456'
+            get_cik_acc(cik, acc)
+            get_cik_acc(acc, cik)
+            get_cik_acc(namedtuple('foo', ['cik', 'accession'])(cik=cik, accession=acc))
+            get_cik_acc({'cik':cik, 'accession':acc})
+            get_cik_acc({'cik':cik, 'accession':acc, 'gvkey': 1, 'datadate':dt.date(2020,1,1)})
+            get_cik_acc({'cik':cik, 'accession':acc, 'gvkey': 1, 'datadate':dt.date(2020,1,1)}, additional_extract='gvkey datadate'.split())
+            get_cik_acc(**{'cik':cik, 'accession':acc, 'gvkey': 1, 'datadate':dt.date(2020,1,1)}, additional_extract='datadate')
+            get_cik_acc(**{'cik_from':cik, 'accession_from':acc}, additional_extract='cik_from accession_from'.split())
+
+
     Arguments:
-        cik (str,dict,object): String CIK, or object with cik and accession attributes or keys.
-        accession (str): String ACCESSION number, or None if accession in CIK object.
+        positional arguments: will grab the first cik and acccession looking values, put the rest in 'args' key
+        additional_extract (str, list): one (str) or more (list) additional keywords to extract from inputs
+        kwargs: will overwrite any positional arg matches, put non-looked for
 
     Returns:
-        tuple: Tuple of (cik, accession)
+        tuple: Tuple of (cik, accession, etc?)
     """
-    try:  # cik has cik/acc attributes?
-        accession = cik.accession if accession is None else accession
-        cik = cik.cik
-    except AttributeError:
-        try:  # cik is dict?
-            accession = cik.get("accession") if accession is None else accession
-            cik = cik.get("cik")
-        except AttributeError:
-            # Hopefully cik is a cik, and acc is an acc
-            cik = int(cik)
+    _ret = {}
+    _unused_args = []
+    _unused_kwargs = {}
 
-    # why this would happen, who knows. But it might?
-    if accession is not None and not isinstance(accession, str):
-        try:  # acc has acc attribute?
-            accession = accession.accession
-        except AttributeError:
-            try:  # acc is dict?
-                accession = accession.get("accession")
-            except AttributeError:
-                # Whelp, we tried. Errors will abound downstream.
-                pass
+    if additional_extract is None:
+        additional_extract = []
+    elif isinstance(additional_extract, str):
+        additional_extract = [additional_extract]
 
-    return cik, accession
+    def _get_thing(thing, box_o_things):
+        try:
+            return getattr(box_o_things, thing)
+        except AttributeError:
+            pass
+        try:
+            return box_o_things.get(thing, None)
+        except AttributeError:
+            pass
+        return None
+
+    if len(args):
+        # Here, look for cik & acc, put the rest into
+        for arg in args:
+            if arg is None:
+                continue
+
+            if isinstance(arg, str) and accession_pattern.search(arg):
+                # Definitively an accession
+                if "accession" in _ret:
+                    _unused_args.append(arg)
+                else:
+                    _ret["accession"] = accession_pattern.search(arg).group(0)
+            elif "cik" in _ret:  # If we already have a cik, then don't overwrite it
+                _unused_args.append(arg)
+            elif isinstance(arg, (str, int, float)):  # ciks are just numbers
+                try:
+                    # int of float because pandas might convert cik to float
+                    _ret["cik"] = int(float(arg))
+                except ValueError:  # no TypeError beause of isinstance match above
+                    _unused_args.append(arg)
+            else:
+                # At this point, if cik/acc is num/str format, we handled it.
+                # So we just have dicts/objects to check, then bail
+                _val = _get_thing("cik", arg)
+                if _val is not None:
+                    try:
+                        # int of float because pandas might convert cik to float
+                        _ret["cik"] = int(float(_val))
+                    except (ValueError, TypeError):  # no TypeError beause of isinstance match above
+                        pass
+                _val = _get_thing("accession", arg)
+                if _val is not None:
+                    if isinstance(_val, str) and accession_pattern.search(_val):
+                        # Definitively an accession
+                        if "accession" not in _ret:
+                            _ret["accession"] = accession_pattern.search(_val).group(0)
+
+                for addtl_val in additional_extract:
+                    _val = _get_thing(addtl_val, arg)
+                    if _val is not None:
+                        _ret[addtl_val] = _val
+                # We don't know if we used them all, so tack the dict/obj on to the 'unused'
+                _unused_args.append(arg)
+
+    if len(kwargs):
+        try:
+            # int of float because pandas might convert cik to float
+            _ret["cik"] = int(float(kwargs["cik"]))
+        except (ValueError, TypeError, KeyError):
+            # Wasn't the right type/parseable, or no cik key
+            pass
+
+        _val = kwargs.get("accession", None)
+        if isinstance(_val, str) and accession_pattern.search(_val):
+            # Definitively an accession
+            _ret["accession"] = accession_pattern.search(_val).group(0)
+
+        for addtl_val in additional_extract:
+            _val = kwargs.get(addtl_val, None)
+            if _val is not None:
+                _ret[addtl_val] = _val
+
+        for _key, _val in kwargs.items():
+            if _key not in _ret:
+                _unused_kwargs[_key] = _val
+
+    if len(_unused_args):
+        _ret["args"] = _unused_args
+    if len(_unused_kwargs):
+        _ret["kwargs"] = _unused_kwargs
+        for _key, _val in _unused_kwargs.items():
+            if _key not in _ret:
+                _ret[_key] = _val
+
+    return _ret
 
 
 def parse_date_input(
@@ -111,8 +198,22 @@ def parse_date_input(
     return _d
 
 
+def get_quarter(datetime_in):
+    """
+    Return the quarter (1-4) based on the month.
+    Input is either a datetime object (or object with month attribute) or the month (1-12).
+    """
+    try:
+        return int((datetime_in.month - 1) / 3) + 1
+    except AttributeError:
+        return int((datetime_in - 1) / 3) + 1
+
+
 def iterate_dates(from_date, to_date=None, period="daily", skip_weekends=True, inclusive=True):
     """
+    Iterates over a date range at a given 'periodicity', where the period is represented by the first occuring date.
+    So Q1, 2000 would be `dt.date(2000, 1, 1)`.
+    Can skip weekends, but does not know about holidays.
 
     Arguments:
         from_date (str, datetime, int): Can be datetime, year (int or string), string of format YYYYMMDD
@@ -122,6 +223,9 @@ def iterate_dates(from_date, to_date=None, period="daily", skip_weekends=True, i
         period (str): Periodicity of dates yielded, either `yearly`, `quarterly`, or `daily`. Default to daily.
         skip_weekends (bool): Flag for whether to skip returning weekends (sat/sun). Default: True.
         inclusive (bool): Flag for whether to include the to_date (or the quarter/year of to_date). Default: True.
+
+    Returns:
+        (datetime): Yields datetime objects
     """
     period = str(period).lower()[0]
     _from = parse_date_input(from_date)

--- a/pyedgar/utilities/__init__.py
+++ b/pyedgar/utilities/__init__.py
@@ -16,6 +16,7 @@ import logging as __logging
 
 __logger = __logging.getLogger(__name__)
 
+
 def get_cik_acc(cik, accession=None):
     """
     I found myself wanting to accept flexible cik/acc inputs, and wrote this
@@ -52,12 +53,97 @@ def get_cik_acc(cik, accession=None):
 
     return cik, accession
 
-def datetime_from_string(date):
-    """Convert string date in YYYY-MM-DD format to datetime object."""
-    if isinstance(date, str):
-        date, date_input = __re.sub('[^0-9]', '', date), date
-        if len(date) != 8:
-            __logger.error("Date must be in YYYYMMDD format (spacing ignored). You passed: %r", date_input)
-            return
-        date = __dt.datetime(int(date[:4]), int(date[4:6]), int(date[6:]))
-    return date
+
+def parse_date_input(
+    date,
+    default=None,
+    dt_re=__re.compile(r"([12]\d{3})[^0-9]+(\d\d?)[^0-9]+(\d\d?)"),
+    dtnodelim_re=__re.compile(r"([12]\d{3})(\d\d)(\d\d)"),
+    qtr_re=__re.compile(r"([12]\d{3})[Qq]([1234])"),
+    yr_re=__re.compile(r"[12]\d{3}"),
+):
+    """
+    Casts something to a date.
+    The something can be:
+
+        date: dt.date(2000, 1, 1)
+        year (int or string): 2000 or '2000'
+        date string: 20001231 or 2000-1-5 (the former must be MM, the latter can omit leading 0s)
+        quarter string: 2001Q3
+
+    Arguments:
+        date (str, date, int, None): Input that makes sense cast to a date. Years will be January 1st,
+            quarters will be on the 1st day of the 1st month in the quarter.
+    """
+    if default is None or not hasattr(default, "year"):
+        default = __dt.date.today()
+    _d = None  # keep _d None until it's date, easier for ifs below
+
+    if date is None:
+        _d = default
+    elif isinstance(date, str):
+        _ymd = dt_re.search(date) or dtnodelim_re.search(date)
+        if _ymd:
+            _d = __dt.date(*map(int, _ymd.groups()))
+
+        if _d is None and qtr_re.search(date):
+            _y, _q = map(int, qtr_re.search(date).groups())
+            _d = __dt.date(_y, _q * 3 - 2, 1)
+
+        if _d is None and yr_re.search(date):
+            _d = __dt.date(int(yr_re.search(date).group(0)), 1, 1)
+    else:  # it could be a date, try that
+        try:
+            _d = __dt.date(date.year, date.month, date.day)
+        except AttributeError:
+            pass
+
+    if _d is None:  # well, it's not none, date, or various strings, try int
+        try:
+            _d = __dt.date(int(date), 1, 1)
+        except (TypeError, ValueError):
+            pass
+
+    # We've handled none, dates, int, and strings, so at this point we gotta give up
+    if not hasattr(_d, "year"):
+        raise ValueError("Input format not recognized: {}".format(date))
+
+    return _d
+
+
+def iterate_dates(from_date, to_date=None, period="daily", skip_weekends=True, inclusive=True):
+    """
+
+    Arguments:
+        from_date (str, datetime, int): Can be datetime, year (int or string), string of format YYYYMMDD
+            or YYYY-M-D, or string of format YYYYq[1234].
+        to_date (str, datetime, int, None): Can be datetime, year (int or string), string of format YYYYMMDD
+            or YYYY-M-D, or string of format YYYYq[1234]. Default: today.
+        period (str): Periodicity of dates yielded, either `yearly`, `quarterly`, or `daily`. Default to daily.
+        skip_weekends (bool): Flag for whether to skip returning weekends (sat/sun). Default: True.
+        inclusive (bool): Flag for whether to include the to_date (or the quarter/year of to_date). Default: True.
+    """
+    period = str(period).lower()[0]
+    _from = parse_date_input(from_date)
+    _to = parse_date_input(to_date)
+
+    if _from > _to:  # greater than means after in date math
+        _from, _to = _to, _from
+
+    if period == "y":
+        for i_yr in range(_from.year, _to.year + inclusive):
+            yield __dt.date(i_yr, 1, 1)
+    elif period == "q":
+        _yqfrom = _from.year * 4 + (_from.month - 1) // 3
+        _yqto = _to.year * 4 + (_to.month - 1) // 3
+        for i_qtr in range(_yqfrom, _yqto + inclusive):
+            # Now reverse the yr * 4 + qtr math above.
+            # I solved this mathematically, without error.
+            # Definitely not trial and error in a notebook.
+            yield __dt.date(i_qtr // 4, (i_qtr % 4) * 3 + 1, 1)
+    else:
+        for i_date in range(_from.toordinal(), _to.toordinal() + inclusive):
+            i_date = __dt.date.fromordinal(i_date)
+            if skip_weekends and i_date.weekday() >= 5:
+                continue
+            yield i_date

--- a/pyedgar/utilities/edgarcache.py
+++ b/pyedgar/utilities/edgarcache.py
@@ -78,7 +78,7 @@ class EDGARCacher(object):
         if keep_form_type_regex is None and config.KEEP_REGEX:
            self.keep_regex = re.compile(config.KEEP_REGEX)
 
-        self._downloader = edgarweb.EDGARDownloader(use_tqdm=use_tqdm)
+        self._downloader = edgarweb.EDGARDownloader()
 
         self._get_filing_path = localstore.get_filing_path
         self._get_feed_cache_path = config.get_feed_cache_path

--- a/pyedgar/utilities/edgarcache.py
+++ b/pyedgar/utilities/edgarcache.py
@@ -82,7 +82,7 @@ class EDGARCacher(object):
         self._logger.debug("Filing root: %r | %r", config.FILING_ROOT, config.FILING_PATH_FORMAT)
         self._logger.debug("Index cache: %r | %r", config.INDEX_CACHE_ROOT, config.INDEX_CACHE_PATH_FORMAT)
         self._logger.debug("Index root: %r | form_*.%s", config.INDEX_ROOT, config.INDEX_EXTENSION)
-        self._logger.debug("Extract regex: %r", self.keep_regex.pattern)
+        self._logger.debug("Extract regex: %r", self.keep_regex.pattern if self.keep_regex else "ALL")
 
     def _handle_nc(self, file_or_str):
         """
@@ -217,11 +217,11 @@ class EDGARCacher(object):
                 EDGAR if they don't exist, or just use the already downloaded files. Default: False.
             overwrite (bool): Flag for whether to overwrite filings if they have already been extracted. Default: False.
         """
-        num_extracted, num_total, num_parsed = 0, 0, 0
+        num_extracted, num_total, num_parsed, i_extracted, i_searched = 0, 0, 0, 0, 0
 
         for i_date in utilities.iterate_dates(from_date, to_date=to_date, period="daily"):
             if download_first:
-                feed_path, _ = edgarweb.download_feed(i_date, overwrite=overwrite, use_requests=self._use_requests)
+                feed_path = edgarweb.download_feed(i_date, overwrite=overwrite, use_requests=self._use_requests)
             else:
                 feed_path = self._get_feed_cache_path(i_date)
 

--- a/pyedgar/utilities/edgarcache.py
+++ b/pyedgar/utilities/edgarcache.py
@@ -20,16 +20,13 @@ import os
 import re
 import tarfile
 import logging
-import subprocess
-import datetime as dt
-from time import sleep
 
 # 3rd party imports
 
 # Module Imports
-from pyedgar.exceptions import (InputTypeError, WrongFormType,
-                                NoFormTypeFound, NoCIKFound)
+from pyedgar.exceptions import InputTypeError, WrongFormType, NoFormTypeFound, NoCIKFound
 from pyedgar import config
+from pyedgar import utilities
 from pyedgar.utilities import localstore
 from pyedgar.utilities import forms
 from pyedgar.utilities import edgarweb
@@ -41,8 +38,9 @@ class EDGARCacher(object):
     Everyone should have a local copy after all!
     I have just enough flexibility here for my computer. It works on Linux, YWindowsMMV.
     """
+
     # These should work for everypeople.
-    EDGAR_ENCODING = 'latin-1' # The SEC documentation says it uses latin-1
+    EDGAR_ENCODING = "latin-1"  # The SEC documentation says it uses latin-1
     # EDGAR_ENCODING = 'utf-8' # Alternatively one could use utf-8.
 
     # These should be changed for you. Either in source, or more better at runtime.
@@ -51,7 +49,7 @@ class EDGARCacher(object):
 
     # Class local vars
     _path_formatter = None
-    _downloader = None
+    _use_requests = False
 
     # Local versions of file path lookups, for overriding if you like
     _get_filing_path = None
@@ -61,10 +59,7 @@ class EDGARCacher(object):
     # May as well share this across instances (instead of setting in __init__)
     _logger = logging.getLogger(__name__)
 
-    def __init__(self,
-                 keep_form_type_regex=None,
-                 check_cik=False,
-                 use_tqdm=True):
+    def __init__(self, keep_form_type_regex=None, check_cik=False, use_tqdm=True, use_requests=False):
         """
         Initialize the downloader object.
 
@@ -73,16 +68,21 @@ class EDGARCacher(object):
         use_tqdm: flag for whether or not to wrap downloads in tqdm for progress monitoring
         """
         self.check_cik = check_cik
+        self._use_requests = use_requests
 
         self.keep_regex = keep_form_type_regex
         if keep_form_type_regex is None and config.KEEP_REGEX:
-           self.keep_regex = re.compile(config.KEEP_REGEX)
-
-        self._downloader = edgarweb.EDGARDownloader()
+            self.keep_regex = re.compile(config.KEEP_REGEX)
 
         self._get_filing_path = localstore.get_filing_path
         self._get_feed_cache_path = config.get_feed_cache_path
         self._get_index_cache_path = config.get_index_cache_path
+
+        self._logger.debug("Feed cache: %r | %r", config.FEED_CACHE_ROOT, config.FEED_CACHE_PATH_FORMAT)
+        self._logger.debug("Filing root: %r | %r", config.FILING_ROOT, config.FILING_PATH_FORMAT)
+        self._logger.debug("Index cache: %r | %r", config.INDEX_CACHE_ROOT, config.INDEX_CACHE_PATH_FORMAT)
+        self._logger.debug("Index root: %r | form_*.%s", config.INDEX_ROOT, config.INDEX_EXTENSION)
+        self._logger.debug("Extract regex: %r", self.keep_regex.pattern)
 
     def _handle_nc(self, file_or_str):
         """
@@ -102,49 +102,50 @@ class EDGARCacher(object):
         if not txt:
             raise InputTypeError("No text of file object found")
 
-        for _decode_type, _errors in zip((self.EDGAR_ENCODING, 'utf-8', 'latin-1'),
-                                         ('strict', 'strict', 'ignore')):
+        for _decode_type, _errors in zip((self.EDGAR_ENCODING, "utf-8", "latin-1"), ("strict", "strict", "ignore")):
             try:
                 txt = txt.decode(_decode_type, errors=_errors)
+                break
             except (UnicodeDecodeError, ValueError):
-                continue
-            break
+                pass
 
-        ret_val = {'doc': txt, 'encoding':_decode_type, 'decode_errors':_errors}
+        ret_val = {"doc": txt, "encoding": _decode_type, "decode_errors": _errors}
 
         if self.keep_regex is not None:
-            ret_val['form_type'] = forms.get_header(txt, "FORM-TYPE")
+            ret_val["form_type"] = forms.get_header(txt, "FORM-TYPE")
 
-            if not ret_val['form_type']:
-                raise NoFormTypeFound(ret_val['form_type'])
+            if not ret_val["form_type"]:
+                raise NoFormTypeFound(ret_val["form_type"])
 
-            if not self.keep_regex.search(ret_val['form_type']):
-                raise WrongFormType(ret_val['form_type'])
+            if not self.keep_regex.search(ret_val["form_type"]):
+                raise WrongFormType(ret_val["form_type"])
 
         if self.check_cik:
-            ret_val['cik'] = forms.get_header(txt, "CIK")
-            ret_val['accession'] = forms.get_header(txt, 'ACCESSION-NUMBER')
+            ret_val["cik"] = forms.get_header(txt, "CIK")
+            ret_val["accession"] = forms.get_header(txt, "ACCESSION-NUMBER")
 
-            if not ret_val['cik']:
+            if not ret_val["cik"]:
                 raise NoCIKFound("No CIK found in {}".format(txt[:250]))
 
         return ret_val
 
-    def extract_from_feed_cache(self, cache_path, overwrite=True):
+    def extract_from_feed_cache(self, cache_path, overwrite=False):
         """
-        Loop through daily feed compressed files and extract them to local cache.
-        Uses the object's path formatter to determine file paths.
+        Extract all filings from a daily feed compressed cache file.
+        Uses `self._get_filing_path` to determine location for extracted filings.
+
+        Extracts filings based on regular expression match of form type if `self.keep_regex` is not None.
         """
         i_done, i_tot = 0, 0
 
-        with tarfile.open(cache_path, 'r') as tar:
+        with tarfile.open(cache_path, "r") as tar:
             for tarinfo in tar:
-                if len(tarinfo.name) < 3 or '.corr' in tarinfo.name:
+                if len(tarinfo.name) < 3 or ".corr" in tarinfo.name:
                     continue
                 i_tot += 1
 
                 # tarinfo.name of form ./ACCESSION.nc
-                nc_acc = tarinfo.name.split('/')[-1][:-3]
+                nc_acc = tarinfo.name.split("/")[-1][:-3]
                 if len(nc_acc) != 20:
                     self._logger.warning("\tAccession in filename seems suspect. %r", nc_acc)
 
@@ -158,36 +159,35 @@ class EDGARCacher(object):
                 try:
                     nc_dict = self._handle_nc(nc_file)
                 except InputTypeError:
-                    self._logger.warning("\tNot a file or string at %r (%r/%r extracted)",
-                                         tarinfo.name, i_done, i_tot)
+                    self._logger.warning("\tNot a file or string at %r (%r/%r extracted)", tarinfo.name, i_done, i_tot)
                     continue
                 except NoCIKFound:
                     # This only triggers if self.check_cik is set.
-                    self._logger.warning("\tNo CIK found at %r (%r/%r extracted)",
-                                         tarinfo.name, i_done, i_tot)
+                    self._logger.warning("\tNo CIK found at %r (%r/%r extracted)", tarinfo.name, i_done, i_tot)
                     continue
                 except NoFormTypeFound:
                     # This only triggers if self.keep_regex is set.
-                    self._logger.warning("\tNo FormType found at %r (%r/%r extracted)",
-                                         tarinfo.name, i_done, i_tot)
+                    self._logger.warning("\tNo FormType found at %r (%r/%r extracted)", tarinfo.name, i_done, i_tot)
                     continue
                 except WrongFormType:
                     # This only triggers if self.keep_regex is set.
                     continue
 
                 try:
-                    nc_text = nc_dict.pop('doc')
-                    if 'accession' not in nc_dict:
-                        nc_dict['accession'] = nc_acc
+                    nc_text = nc_dict.pop("doc")
+                    if "accession" not in nc_dict:
+                        nc_dict["accession"] = nc_acc
                 except AttributeError:
                     # None type has no pop
-                    self._logger.warning("\tHandling nc file %r passed exceptions (%r/%r extracted)",
-                                         tarinfo.name, i_done, i_tot)
+                    self._logger.warning(
+                        "\tHandling nc file %r passed exceptions (%r/%r extracted)", tarinfo.name, i_done, i_tot
+                    )
                     continue
                 except KeyError:
                     # This triggers upon nc_dict.pop not having 'doc' in it. Shouldn't happen.
-                    self._logger.warning("\tNo document item extracted from %r (%r/%r extracted)",
-                                         tarinfo.name, i_done, i_tot)
+                    self._logger.warning(
+                        "\tNo document item extracted from %r (%r/%r extracted)", tarinfo.name, i_done, i_tot
+                    )
                     continue
 
                 # Get local nc file path. Accession is nc file filename.
@@ -200,63 +200,12 @@ class EDGARCacher(object):
                 if not os.path.exists(os.path.dirname(nc_out_path)):
                     os.makedirs(os.path.dirname(nc_out_path))
 
-                with open(nc_out_path, 'w', encoding=nc_dict['encoding'], errors=nc_dict['decode_errors']) as fh:
+                with open(nc_out_path, "w", encoding=nc_dict["encoding"], errors=nc_dict["decode_errors"]) as fh:
                     fh.write(nc_text)
 
         return i_done, i_tot
 
-
-    def iterate_daily_feeds(self, from_date, to_date=None):
-        """
-        Generator that yields (dt.date, daily feed tar file path)
-        """
-        if to_date is None:
-            to_date = dt.date.today()
-
-        for i_date in range(from_date.toordinal(), to_date.toordinal()):
-            # i_date is ordinal number, so cast it to date
-            yield dt.date.fromordinal(i_date), self._get_feed_cache_path(i_date)
-
-    def download_daily_feed(self, dl_date, overwrite=False, resume=True):
-        """Download a daily feed tar given a datetime input."""
-        sec_path = edgarweb.get_feed_url(dl_date)
-        local_path = self._get_feed_cache_path(dl_date)
-
-        if overwrite:
-            try:
-                os.remove(local_path)
-            except Exception:
-                pass
-
-        return self._downloader.download_tar(sec_path, local_path, resume=resume)
-
-    def download_quarterly_index(self, dl_date, compressed=True, overwrite=False, resume=True):
-        """Download a quarterly index given a datetime input."""
-        # For now, get the IDX file, not the zipped file. Because laziness and edu internet.
-        sec_path = edgarweb.get_index_url(dl_date, compressed=compressed)
-        local_path = self._get_index_cache_path(dl_date)
-
-        if overwrite:
-            try:
-                os.remove(local_path)
-            except Exception:
-                pass
-
-        if compressed:
-            return self._downloader.download_tar(sec_path, local_path, resume=resume)
-
-        return self._downloader.download_plaintext(sec_path, local_path)
-
-    def download_many_feeds(self, from_date, to_date=None):
-        """
-        Generator that yields (dt.date, downloaded daily feed tar file path)
-        """
-        for i_date, _ in self.iterate_daily_feeds(from_date, to_date=to_date):
-            # Actually get the file. This downloads it, or passes the filepath to the cached file.
-            yield i_date, self.download_daily_feed(i_date)
-
-
-    def extract_daily_feeds(self, from_date, to_date=None, download_first=True):
+    def extract_daily_feeds(self, from_date, to_date=None, download_first=False, overwrite=False):
         """
         Loop through daily feed compressed files and extract them to local cache.
         Uses the object's path formatter to determine file paths.
@@ -266,37 +215,37 @@ class EDGARCacher(object):
             to_date (datetime): Optional day to finish extracting on. Default: datetime.date.today()
             download_first (bool): Flag for whether to try and download daily feed cache files from
                 EDGAR if they don't exist, or just use the already downloaded files. Default: False.
+            overwrite (bool): Flag for whether to overwrite filings if they have already been extracted. Default: False.
         """
         num_extracted, num_total, num_parsed = 0, 0, 0
 
-        iter_func = self.download_many_feeds if download_first else self.iterate_daily_feeds
+        for i_date in utilities.iterate_dates(from_date, to_date=to_date, period="daily"):
+            if download_first:
+                feed_path, _ = edgarweb.download_feed(i_date, overwrite=overwrite, use_requests=self._use_requests)
+            else:
+                feed_path = self._get_feed_cache_path(i_date)
 
-        for i_date, feed_path in iter_func(from_date, to_date=to_date):
-            if not feed_path:
-                # This day doesn't exist on EDGAR.
-                # Not sure why servers can't work on weekends.
+            if feed_path is None or not os.path.exists(feed_path):
+                self._logger.info("Cache file does not exist for %s at %s.", i_date, feed_path)
                 continue
 
-            if not os.path.exists(feed_path):
-                self._logger.warning("Cache file does not exist for %s at %s.",
-                                   i_date, feed_path)
-                continue
-
-            self._logger.info("Daily feed cache %s: %4.2f MB",
-                              i_date, os.path.getsize(feed_path)/1024**2)
+            self._logger.info(
+                "%s feed file %s: %4.2f MB",
+                "Downloaded" if download_first else "Parsing",
+                i_date,
+                os.path.getsize(feed_path) / 1024 ** 2,
+            )
 
             try:
-                i_extracted, i_searched = self.extract_from_feed_cache(feed_path)
+                i_extracted, i_searched = self.extract_from_feed_cache(feed_path, overwrite=overwrite)
             except tarfile.ReadError:
-                self._logger.error("Handling nc file on %s at %s raised Read Error",
-                                   i_date, feed_path)
+                self._logger.error("Handling nc file on %s at %s raised Read Error", i_date, feed_path)
 
             # Log progress after each tar file is done
-            self._logger.info("Finished adding %d out of %d from %s\n",
-                              i_extracted, i_searched, feed_path)
+            self._logger.info("Extracted %d out of %d filings from %s", i_extracted, i_searched, feed_path)
 
             num_extracted += i_extracted
             num_total += i_searched
             num_parsed += 1
 
-        num_extracted, num_total, num_parsed
+        return num_extracted, num_total, num_parsed

--- a/pyedgar/utilities/edgarweb.py
+++ b/pyedgar/utilities/edgarweb.py
@@ -16,84 +16,93 @@ EDGAR HTML specification: https://www.sec.gov/info/edgar/ednews/edhtml.htm
 :license: MIT, see LICENSE for more details.
 """
 
+# Stdlib imports
 import os
-# import sys
 import re
-# import tarfile
 import logging
-# import datetime as dt
+import subprocess
+
+# 3rd party imports
 import requests
+
+# Module Imports
+from pyedgar import config
+from pyedgar import utilities
 
 # Local logger
 _logger = logging.getLogger(__name__)
 
-try:
-    def _faketqdm(x, *args, **kwargs):
-        return x
-    from tqdm import tqdm as _tqdm
-except ModuleNotFoundError:
-    _tqdm = _faketqdm
-
-
 # Constants
 # Used to be (before FTP changed to AWS S3): ftp://ftp.sec.gov
-EDGAR_ROOT = 'https://www.sec.gov/Archives'
+EDGAR_ROOT = "https://www.sec.gov/Archives"
+REQUEST_HEADERS = {
+    "User-Agent": getattr(
+        config, "USER_AGENT", "pyedgar downloader (fallback UA, shame) from gaulinmp+badpyedgarUA@gmail.com"
+    )
+}
 
 
-def parse_url(url):
+def parse_url(url, url_re=re.compile(r"/(?P<cik>\d{1,10})/" r"(?P<accession>\d{10}-?\d\d-?\d{6})", re.I)):
     """Return CIK and Accession from an EDGAR HTTP or FTP url.
 
-    :param string url: URL from EDGAR website or FTP server.
+    Arguments:
+        url (string): URL from EDGAR website or FTP server.
+        url_re (Pattern): regular expression with cik and accession groups
 
-    :return: Tuple of strings in the form (cik, accession) or (None, None)
-    :rtype: tuple (string/None, string/None)
+    Returns:
+        tuple: Tuple of strings in the form (cik, accession) or (None, None)
     """
-    url_re = re.compile(r'/(?P<cik>\d{1,10})/'
-                        r'(?P<accession>\d{10}-?\d\d-?\d{6})', re.I)
     res = url_re.search(url)
     if res:
-        acc = res.group('accession')
+        acc = res.group("accession")
         if len(acc) == 18:
-            acc = acc[:10] + '-' + acc[10:12] + '-' + acc[12:]
-        return res.group('cik'), acc
+            acc = acc[:10] + "-" + acc[10:12] + "-" + acc[12:]
+        return res.group("cik"), acc
     return None, None
+
 
 def get_edgar_urls(cik, accession=None):
     """Generage URLs for EDGAR 'bulk download' and 'user facing' sites.
     `cik` parameter can be object with `cik` and `accession` attributes or keys.
 
-    :param string,object cik: String CIK, or object with cik and accession attributes or keys.
-    :param string accession: String ACCESSION number, or None if accession in CIK object.
+    Arguments:
+        cik (str,dict,object): String CIK, or object with cik and accession attributes or keys.
+        accession (str): String ACCESSION number, or None if accession in CIK object.
 
-    :return: Tuple of strings in the form (bulk DL url, user website url)
-    :rtype: tuple (string, string)
+    Returns:
+        tuple: Tuple of strings in the form (raw url, Filing Index url)
     """
-    if accession is None:
-        try: # cik has cik/acc attributes?
-            cik = cik.cik
-            accession = cik.accession if accession is None else accession
-        except AttributeError:
-            try: # cik is dict?
-                cik = cik.get('cik')
-                accession = cik.get('accession')
-            except AttributeError:
-                pass
+    cik,accession = utilities.get_cik_acc(cik, accession=accession)
 
-    return ('{}/edgar/data/{}/{}.txt'.format(EDGAR_ROOT, cik, accession),
-            '{}/edgar/data/{}/{}-index.htm'.format(EDGAR_ROOT, cik, accession))
+    return (
+        "{}/edgar/data/{}/{}.txt".format(EDGAR_ROOT, cik, accession),
+        "{}/edgar/data/{}/{}-index.htm".format(EDGAR_ROOT, cik, accession),
+    )
 
-def edgar_links(cik, accession=None):
+
+def edgar_links(cik, accession=None, index=True, raw=True):
     """Generage HTML encoded links (using `a` tag) to EDGAR 'bulk download' and 'user facing' sites.
     `cik` parameter can be object with `cik` and `accession` attributes or keys.
 
-    :param string,object cik: String CIK, or object with cik and accession attributes or keys.
-    :param string accession: String ACCESSION number, or None if accession in CIK object.
+    Arguments:
+        cik (str,dict,object): String CIK, or object with cik and accession attributes or keys.
+        accession (str): String ACCESSION number, or None if accession in CIK object.
+        index (bool): Include link to Index of accession
+        raw (bool): Include link to raw text of accession
 
-    :return: String of HTTP encoded links
-    :rtype: string
+    Returns:
+        str: HTML `a` tag with href pointing to EDGAR index and/or raw file of of `accession`.
     """
-    return ("<a href='{1}' target=_blank>Index</a> <a href='{0}' target=_blank>Raw</a>"
-            .format(*get_edgar_urls(cik, accession=accession)))
+    _raw,_idx = get_edgar_urls(cik, accession=accession)
+
+    _html = []
+    if index:
+        _html.append("<a href='{}' target=_blank>Index</a>".format(_idx))
+    if raw:
+        _html.append("<a href='{}' target=_blank>Raw</a>".format(_raw))
+
+    return ' '.join(_html)
+
 
 def _get_qtr(datetime_in):
     """
@@ -101,167 +110,226 @@ def _get_qtr(datetime_in):
     Input is either a datetime object (or object with month attribute) or the month (1-12).
     """
     try:
-        return int((datetime_in.month-1)/3)+1
+        return int((datetime_in.month - 1) / 3) + 1
     except AttributeError:
-        pass
-    return int((datetime_in-1)/3)+1
+        return int((datetime_in - 1) / 3) + 1
 
-def get_feed_path(date):
-    """Get URL path to daily feed gzip file."""
-    feed_path = "/edgar/Feed/{0:%Y}/QTR{1}/{0:%Y%m%d}.nc.tar.gz"
-    return feed_path.format(date, _get_qtr(date))
 
-def get_idx_path(date_or_year, quarter=None, compressed=False):
+def get_feed_url(date):
+    """Get URL path to daily feed gzip file.
+
+    Arguments:
+        date (datetime): Date for feed file
+
+    Returns:
+        str: URL to feed file on `date`"""
+    return "{0}/edgar/Feed/{1:%Y}/QTR{2}/{1:%Y%m%d}.nc.tar.gz".format(EDGAR_ROOT, date, _get_qtr(date))
+
+
+def get_index_url(date_or_year, quarter=None, compressed=True):
     """
     Get URL path to quarterly index file.
     Do not feed it a year and no quarter.
+
+    Arguments:
+        date_or_year (datetime,int): Datetime from which the index's quarter will be calculated, or integer year
+        quarter (int,None): Quarter of the index, will be inferred from date_or_year if None.
     """
-    if quarter is None:
-        quarter = _get_qtr(date_or_year)
     try:
         date_or_year = date_or_year.year
+        # Leave this here, because if date_or_year isn't a datetime, we can't calculate the quarter. So error out.
+        if quarter is None:
+            quarter = _get_qtr(date_or_year)
     except AttributeError:
         # Then date_or_year is an integer. Leave it be.
-        pass
+        if quarter is None:
+            raise AttributeError("Must either pass either datetime or both integer year AND quarter")
 
-    return ("/edgar/full-index/{0}/QTR{1}/master.{2}"
-            .format(date_or_year, quarter, 'gz' if compressed else 'idx'))
+    ext = "gz" if compressed else "idx"
 
-def download_form_from_web(cik, accession):
+    return "{0}/edgar/full-index/{1}/QTR{2}/master.{3}".format(EDGAR_ROOT, date_or_year, quarter, ext)
+
+
+def download_form_from_web(cik, accession=None):
     """
     Sometimes the cache file is not there, or you do not have local cache.
     In those cases, you can download the EDGAR forms from S3 directly.
 
-    NOTE: None of the header parsing functionality will work because the Web
-          version of EDGAR converts the SGML header to indented plain text.
+    Arguments:
+        cik (str,dict,object): String CIK, or object with cik and accession attributes or keys.
+        accession (str): String ACCESSION number, or None if accession in CIK object.
+
+    Returns:
+        tuple: Tuple of strings in the form (bulk DL url, user website url)
     """
+    _raw,_ = get_edgar_urls(cik, accession=accession)
 
-    cik = int(cik)
-    try:
-        url = get_edgar_urls(int(cik), accession)[0]
-    except ValueError:
-        _logger.exception("CIK must be an integer: %r", cik)
-        raise
-
-    r = requests.get(url)
+    r = requests.get(_raw, headers=REQUEST_HEADERS)
 
     data = r.content
 
-    for _decode_type, _errors in zip(('latin-1', 'utf-8', 'latin-1'),
-                                     ('strict', 'strict', 'ignore')):
+    for _decode_type, _errors in zip(("latin-1", "utf-8", "latin-1"), ("strict", "strict", "ignore")):
         try:
-            txt = data.decode(_decode_type, errors=_errors)
+            return data.decode(_decode_type, errors=_errors)
         except (UnicodeDecodeError, ValueError):
             continue
-        break
 
-    return txt
+
+def download_from_edgar(edgar_url, local_path, overwrite=False, use_requests=False, chunk_size=10 * 1024 ** 2, overwrite_size_threshold=-1):
+    """
+    Generic downloader, uses curl by default unless use_requests=True is passed in.
+
+    Arguments:
+        edgar_url (str): URL of EDGAR resource.
+        local_path (Path, str): Local path to write to
+        overwrite (bool): Flag for whether to overwrite any existing file (default False).
+        use_requests (bool): Flag for whether to use requests or curl (default False == curl).
+        chunk_size (int): Size of chunks to write to disk while streaming from requests
+        overwrite_size_threshold (int): Existing files smaller than this will be re-downloaded.
+
+    Returns:
+        (str, None): Returns path of downloaded file (or None if download failed).
+    """
+    if not os.path.exists(os.path.dirname(local_path)):
+        raise FileNotFoundError("Trying to write to non-existant directory: {}".format(os.path.dirname(local_path)))
+
+    if os.path.exists(local_path):
+        loc_size = os.path.getsize(local_path)
+        if not overwrite and loc_size > overwrite_size_threshold:
+            _logger.warning("Skipping cache file (%s bytes) at %r", '{:,d}'.format(loc_size), local_path)
+            return local_path
+
+        _logger.warning("Removing existing file (%s bytes) at %r", '{:,d}'.format(loc_size), local_path)
+        os.remove(local_path)
+
+    _useragent = REQUEST_HEADERS["User-Agent"]
+
+    if not use_requests:
+        _logger.info('curl -A "%s" %s -o %s', _useragent, edgar_url, local_path)
+        subp = subprocess.run(["curl", '-A "{}"'.format(_useragent), edgar_url, "-o", local_path])
+        if subp.returncode != 0:
+            raise Exception("Error %r downloading with curl: %r", subp.returncode, subp.stderr)
+    else:
+        _logger.info("requests.get(%r, headers=%r) >> %r", edgar_url, REQUEST_HEADERS, local_path)
+        try:
+            with requests.get(edgar_url, headers=REQUEST_HEADERS, stream=True) as response:
+                expected_len = int(response.headers["content-length"])
+                with open(local_path, "wb") as fh:
+                    for chunk in response.iter_content(chunk_size=chunk_size):
+                        if chunk:  # filter out keep-alive new chunks
+                            fh.write(chunk)
+        except Exception as excp:
+            raise Exception("Error downloading with requests: %r", excp) from excp
+
+        # Now check what we downloaded was what we expected
+        try:
+            loc_size = os.path.getsize(local_path)
+        except FileNotFoundError:
+            raise Exception("Error downloading with requests to: %r", local_path)
+        if expected_len != loc_size:
+            _logger.exception("requests downloaded {:,d} bytes but expected {:,d}".format(loc_size, expected_len))
+
+    if os.path.exists(local_path):
+        return local_path
+    return None
 
 
 class EDGARDownloader(object):
     """
-    Class that downloads files from EDGAR.
-    Supports resuming on compressed (tar) files.
+    Class that downloads feeds, indexes, or filings from EDGAR.
     """
 
     # May as well share this across instances (instead of setting in __init__)
     _logger = logging.getLogger(__name__)
 
-    _tq = None
-
-    def __init__(self, use_tqdm=True):
-        """
-        Initialize the downloader object.
-
-        use_tqdm: sets whether download progress is wrapped in tqdm.
-        """
-        self._tq = _tqdm if use_tqdm else _faketqdm
-
-    def download_tar(self, remote_path, local_target, chunk_size=1024**2, retries=5, resume=True):
-        """Download a file from `remote_path` to `local_target`."""
-        from_addr = ('{edgar_root}{remote_path}'
-                     .format(edgar_root=EDGAR_ROOT, remote_path=remote_path))
+    def download_tar(self, edgar_url, local_target, chunk_size=1024 ** 2, retries=5, resume=True):
+        """Download a file from `edgar_url` to `local_target`."""
 
         # Verify destination directory exists
         if not os.path.exists(os.path.dirname(local_target)):
-            raise FileNotFoundError('The directory does not exist: {}'
-                                    .format(os.path.dirname(local_target)))
+            raise FileNotFoundError("The directory does not exist: {}".format(os.path.dirname(local_target)))
 
         # If it fails, try, try, try, try again. Then stop; accept failure.
         for n_retries in range(retries):
             # Check for local copy and determine length (for caching/resuming)
             try:
                 loc_size = os.path.getsize(local_target)
-                headers = {'Range': 'bytes={loc_size}-'.format(loc_size=loc_size)}
+                headers = {"Range": "bytes={loc_size}-".format(loc_size=loc_size)}
                 # Resume with header: Range: bytes=StartPos- (implicit end pos)
             except FileNotFoundError:
                 loc_size = 0
                 headers = None
 
             # Check total file length on server
-            with requests.get(from_addr, stream=True) as response:
+            with requests.get(edgar_url, stream=True) as response:
                 if response.status_code // 100 == 4:
                     # No such file
                     return None
-                expected_tot_len = int(response.headers['content-length'])
+                expected_tot_len = int(response.headers["content-length"])
 
             # If local length matches, we are done. Return local path
             if expected_tot_len == loc_size:
-                self._logger.info("Already downloaded (%r == %r) from %r to %r",
-                                  loc_size, expected_tot_len, remote_path, local_target)
+                self._logger.info(
+                    "Already downloaded (%r == %r) from %r to %r", loc_size, expected_tot_len, edgar_url, local_target
+                )
                 break
 
             # If local length is longer than server, we done goofed. Delete it and try again.
             if loc_size > expected_tot_len:
-                self._logger.info("Downloaded too much (%r > %r) from %r, removing %r",
-                                  loc_size, expected_tot_len, remote_path, local_target)
+                self._logger.info(
+                    "Downloaded too much (%r > %r) from %r, removing %r",
+                    loc_size,
+                    expected_tot_len,
+                    edgar_url,
+                    local_target,
+                )
                 os.remove(local_target)
                 loc_size = 0
                 headers = None
             elif not resume and (0 < loc_size < expected_tot_len):
-                self._logger.info("No resuming (%r < %r), removing %r",
-                                  loc_size, expected_tot_len, local_target)
+                self._logger.info("No resuming (%r < %r), removing %r", loc_size, expected_tot_len, local_target)
                 os.remove(local_target)
                 loc_size = 0
                 headers = None
 
-            self._logger.info("Downloading %r of %r: %r to %r",
-                              n_retries, retries, remote_path, local_target)
+            self._logger.info("Downloading %r of %r: %r to %r", n_retries, retries, edgar_url, local_target)
 
             # Download or resume
-            with requests.get(from_addr, headers=headers, stream=True) as response:
-                expected_len = int(response.headers['content-length'])
+            with requests.get(edgar_url, headers=headers, stream=True) as response:
+                expected_len = int(response.headers["content-length"])
 
                 if loc_size:
-                    self._logger.info("Already downloaded (%r/%r, remaining: %r) from %r to %r",
-                                      loc_size, expected_tot_len, expected_len, remote_path, local_target)
+                    self._logger.info(
+                        "Already downloaded (%r/%r, remaining: %r) from %r to %r",
+                        loc_size,
+                        expected_tot_len,
+                        expected_len,
+                        edgar_url,
+                        local_target,
+                    )
 
-                with open(local_target, 'ab' if loc_size else 'wb') as fh:
-                    self._logger.info("Saving tar {} to {}"
-                                      .format(remote_path, local_target))
+                with open(local_target, "ab" if loc_size else "wb") as fh:
+                    self._logger.info("Saving tar {} to {}".format(edgar_url, local_target))
 
-                    for chunk in self._tq(response.iter_content(chunk_size=chunk_size),
-                                          total=expected_len//chunk_size,
-                                          unit="Mb",
-                                          desc=os.path.basename(local_target)):
+                    for chunk in self._tq(
+                        response.iter_content(chunk_size=chunk_size),
+                        total=expected_len // chunk_size,
+                        unit="Mb",
+                        desc=os.path.basename(local_target),
+                    ):
                         if chunk:  # filter out keep-alive new chunks
                             fh.write(chunk)
 
-            self._logger.info("Done saving (len: {}) {}"
-                                .format(os.path.getsize(local_target),
-                                        local_target))
+            self._logger.info("Done saving (len: {}) {}".format(os.path.getsize(local_target), local_target))
 
             break  # Done downloading, break out of range(5)
 
         return local_target
 
-    def download_plaintext(self, remote_path, local_target, chunk_size=1024**2, overwrite=True):
+    def download_plaintext(self, edgar_url, local_target, chunk_size=1024 ** 2, overwrite=True):
         """
-        Download a plaintext file from `remote_path` to `local_target`.
+        Download a plaintext file from `edgar_url` to `local_target`.
         """
-        from_addr = ('https://www.sec.gov/Archives{remote_path}'
-                     .format(remote_path=remote_path))
-
         # Return if exists. Delete if it is partial?
         if os.path.exists(local_target):
             if overwrite:
@@ -271,30 +339,29 @@ class EDGARDownloader(object):
 
         # Verify destination directory exists
         if not os.path.exists(os.path.dirname(local_target)):
-            raise FileNotFoundError('The directory does not exist: {}'
-                                    .format(os.path.dirname(local_target)))
+            raise FileNotFoundError("The directory does not exist: {}".format(os.path.dirname(local_target)))
 
-        self._logger.info("Downloading plaintext: %r to %r", remote_path, local_target)
+        self._logger.info("Downloading plaintext: %r to %r", edgar_url, local_target)
 
         # Check total file length on server
-        with requests.get(from_addr, stream=True) as response:
+        with requests.get(edgar_url, stream=True) as response:
             if response.status_code // 100 == 4:
                 # No such file
                 return None
-            expected_tot_len = int(response.headers.get('content-length', 10 * 1024**2))
+            expected_tot_len = int(response.headers.get("content-length", 10 * 1024 ** 2))
 
-            with open(local_target, 'wb') as fh:
-                self._logger.info("Saving plaintext %r to %r", remote_path, local_target)
+            with open(local_target, "wb") as fh:
+                self._logger.info("Saving plaintext %r to %r", edgar_url, local_target)
 
-                for chunk in self._tq(response.iter_content(chunk_size=chunk_size),
-                                      total=expected_tot_len//chunk_size,
-                                      unit="Mb",
-                                      desc=os.path.basename(local_target)):
+                for chunk in self._tq(
+                    response.iter_content(chunk_size=chunk_size),
+                    total=expected_tot_len // chunk_size,
+                    unit="Mb",
+                    desc=os.path.basename(local_target),
+                ):
                     if chunk:  # filter out keep-alive new chunks
                         fh.write(chunk)
 
-        self._logger.info("Done saving (len: {}) {}"
-                            .format(os.path.getsize(local_target),
-                                    local_target))
+        self._logger.info("Done saving (len: {}) {}".format(os.path.getsize(local_target), local_target))
 
         return local_target

--- a/pyedgar/utilities/edgarweb.py
+++ b/pyedgar/utilities/edgarweb.py
@@ -222,10 +222,11 @@ def download_from_edgar(
 
     if not use_requests:
         _logger.info('curl -A "%s" %s -o %s', _useragent, edgar_url, local_path)
-        subp = subprocess.run(["curl", '-A "{}"'.format(_useragent), edgar_url, "-o", local_path])
+        subp = subprocess.run(["curl", '-A "{}"'.format(_useragent), edgar_url, "-o", local_path], capture_output=True)
+        _logger.debug(subp.stdout)
         sleep(sleep_after)
         if subp.returncode != 0:
-            raise Exception("Error %r downloading with curl: %r", subp.returncode, subp.stderr)
+            raise Exception("Error {} downloading with curl: {}".format(subp.returncode, subp.stderr))
     else:
         _logger.info("requests.get(%r, headers=%r) >> %r", edgar_url, REQUEST_HEADERS, local_path)
         try:
@@ -237,7 +238,7 @@ def download_from_edgar(
                             fh.write(chunk)
             sleep(sleep_after)
         except Exception as excp:
-            raise Exception("Error downloading with requests: %r", excp) from excp
+            raise Exception("Error downloading with requests: {}".format(excp)) from excp
 
         # Now check what we downloaded was what we expected
         try:
@@ -264,7 +265,7 @@ def download_feed(date, overwrite=False, use_requests=False, overwrite_size_thre
         sleep_after (int): Number of seconds to sleep after downloading file (default 0)
 
     Returns:
-        tuple: output file path, return code
+        str: output file path
     """
     date = utilities.parse_date_input(date)
 

--- a/pyedgar/utilities/indices.py
+++ b/pyedgar/utilities/indices.py
@@ -140,7 +140,8 @@ class IndexMaker:
         for form, formlist in self._tq(save_forms.items(), total=len(save_forms), desc="Exporting Indices"):
             outpath = os.path.join(config.INDEX_ROOT, "form_{}.{}".format(form, config.INDEX_EXTENSION))
 
-            self._logger.info("Saving %r: %r", outpath, formlist)
+            self._logger.info("Saving %r to %r", form, outpath)
+            self._logger.debug("Saving %s to %s with form-types: %r", form, outpath, formlist)
 
             (
                 df[df["Form Type"].isin(formlist)]


### PR DESCRIPTION
Downloads were buggy and often didn't work, the resume functionality had no error checking and often corrupted the tar files. This has been removed, and a default cURL options has been added. All download functions have `use_requests` arguments to support fallback functionality, and the downloader script checks for the existence of cURL by default.

Additional pyedgar.downloader functionality was added for checking the status of downloaded cache files (`--status` argument) and printing the current config settings (`--config` argument). Additionally, the extract flag was removed, so now by default the downloader script download/extracts indexes with `-i` and feeds with `-d`.